### PR TITLE
Use year of first publication in LICENSE.md

### DIFF
--- a/firmware/LICENSE.md
+++ b/firmware/LICENSE.md
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2023-2024, University College London
+Copyright (c) 2023, University College London
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
This PR updates the copyright year in LICENSE.md to use the year of first publication. See also https://hynek.me/til/copyright-years/